### PR TITLE
This adds a terrible little load testing script

### DIFF
--- a/files/download_catalogs.sh
+++ b/files/download_catalogs.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+#
+# Just force the master to compile a bunch of catalogs concurrently.
+#
+# Usage: download_catalogs.sh <number of runs> <seconds to sleep between requests>
+#
+
+if [ "$#" -eq 0 ]; then
+    echo "This is a silly shell script to request many concurrent catalog compiles."
+    echo "It's used for very simple load testing."
+    echo
+    echo "Usage: download_catalogs.sh <number of runs> <seconds to sleep between requests>"
+    echo
+    exit 1
+fi
+
+NUM=${1-5}
+DELAY=${2-3}
+
+# This just makes sure the master has facts for our node, and doesn't blow up
+# due to the trusted fact kerfuffle.
+puppet agent -t --noop
+
+for i in $(seq 1 ${NUM})
+do
+    $(puppet catalog download > /dev/null 2>&1) &
+    sleep ${DELAY}
+done

--- a/files/run_agents
+++ b/files/run_agents
@@ -30,9 +30,14 @@ For example:
         options[:mode] = :reset
     end
 
-    opts.on("-c [INTERVAL]", "--concurrent [INTERVAL]", Integer,
-            "Run agents concurrently. Specify interval between runs or default to 3.") do |opt|
-        options[:interval] = opt || 3
+    opts.on("-c [COUNT]", "--concurrent [COUNT]",
+            "Run this many agents concurrently. Defaults to 3.") do |opt|
+        options[:concurrent] = opt || '3'
+    end
+
+    opts.on("-d DELAY", "--delay DELAY",
+            "Specify interval between concurrent runs.") do |opt|
+        options[:interval] = opt
     end
 
     opts.on("-i IDENTITY", "--identity IDENTITY", "Run the agent on the specified container.") do |opt|
@@ -81,10 +86,11 @@ when :all
   puts 'Triggering agent runs:'
   containers.each do |identity|
     puts "############# #{identity} ###############"
-    if options.include? :interval
+    if options.include? :concurrent
+      options[:interval] ||= '3'
       # Detach from process so we don't have to wait for it to complete
-      system('docker', 'exec', '-d', identity, 'puppet', 'agent', '-t', *ARGV)
-      sleep options[:interval]
+      system('docker', 'exec', '-d', identity, 'download_catalogs.sh', options[:concurrent], options[:interval])
+      sleep options[:interval].to_i
     else
       system('docker', 'exec', identity, 'puppet', 'agent', '-t', *ARGV)
     end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,12 @@ class dockeragent {
     }
   }
 
+  file { "/etc/docker/agent/download_catalogs.sh":
+    ensure  => file,
+    mode    => '0755',
+    source  => 'puppet:///modules/dockeragent/download_catalogs.sh',
+  }
+
   file { '/usr/local/bin/run_agents':
     ensure => file,
     mode   => '0755',

--- a/templates/Dockerfile.epp
+++ b/templates/Dockerfile.epp
@@ -14,4 +14,5 @@ RUN rm /etc/yum.repos.d/CentOS*
 ADD base_local.repo /etc/yum.repos.d/base_local.repo
 ADD epel_local.repo /etc/yum.repos.d/epel_local.repo
 ADD updates_local.repo /etc/yum.repos.d/updates_local.repo
+ADD download_catalogs.sh /usr/local/bin/download_catalogs.sh
 RUN yum clean all


### PR DESCRIPTION
It initiates multiple concurrent catalog requests. I've experimentally
verified that these compiles occur concurrently on the master.

usage: download_catalogs.sh <number> <delay>
