### PR TITLE
Files for cron permissions in containers

### DIFF
--- a/files/crond.pam
+++ b/files/crond.pam
@@ -1,0 +1,10 @@
+#
+# The PAM configuration file for the cron daemon
+#
+#
+# No PAM authentication called, auth modules not needed
+account    required   pam_access.so
+account    include    password-auth
+#session    required   pam_loginuid.so
+session    include    password-auth
+auth       include    password-auth

--- a/files/crond.pam
+++ b/files/crond.pam
@@ -5,6 +5,6 @@
 # No PAM authentication called, auth modules not needed
 account    required   pam_access.so
 account    include    password-auth
-#session    required   pam_loginuid.so
+session    optional   pam_loginuid.so
 session    include    password-auth
 auth       include    password-auth

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,12 @@ class dockeragent (
     mode    => '0644',
     source  => 'puppet:///modules/dockeragent/root.cron',
   }
+  
+  file { "/etc/docker/agent/crond.pam":
+    ensure  => file,
+    mode    => '0644',
+    source  => 'puppet:///modules/dockeragent/crond.pam',
+  }
 
   file { '/usr/local/bin/run_agents':
     ensure => file,

--- a/templates/Dockerfile.epp
+++ b/templates/Dockerfile.epp
@@ -17,3 +17,4 @@ ADD puppet.conf /etc/puppetlabs/puppet/puppet.conf
 ADD download_catalogs.sh /usr/local/bin/download_catalogs.sh
 ADD refresh-mcollective-metadata /usr/local/bin/refresh-mcollective-metadata
 ADD root.cron /var/spool/cron/root
+ADD crond.pam /etc/pam.d/crond


### PR DESCRIPTION
This lets cron actually run on the containers.

It's probably horribly insecure, but it works.
