### PR TITLE
Init system for containers

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -16,7 +16,7 @@ define dockeragent::node (
     ],
   }
 
-  exec { "docker exec -d ${title} /sbin/init 3":
+  exec { "docker exec -d ${title} /usr/lib/systemd/systemd":
     path         => ['/usr/bin','/bin'],
     refreshonly  => true,
     subscribe    => Docker::Run[$title],

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -7,7 +7,7 @@ define dockeragent::node (
   docker::run { $title:
     hostname         => $title,
     image            => 'agent',
-    command          => '/sbin/init 3',
+    command          => '/usr/lib/systemd/systemd',
     ports            => $ports,
     volumes          => $dockeragent::container_volumes,
     extra_parameters => [

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -15,10 +15,4 @@ define dockeragent::node (
       '--restart=always',
     ],
   }
-
-  exec { "docker exec -d ${title} /usr/lib/systemd/systemd":
-    path         => ['/usr/bin','/bin'],
-    refreshonly  => true,
-    subscribe    => Docker::Run[$title],
-  }
 }

--- a/templates/Dockerfile.epp
+++ b/templates/Dockerfile.epp
@@ -1,6 +1,6 @@
-# Builds a basic Centos<%= $os_major %> container with pe-agent installed
+# Builds a basic Centos container with pe-agent installed
 # This image is for training purposes and is not intended for production environments.
-FROM <%= $basename %>:<%= $os_major %>
+FROM maci0/systemd
 MAINTAINER Josh Samuelson <js@puppetlabs.com>
 ENV HOME /root/
 ENV TERM xterm


### PR DESCRIPTION
the maci0/systemd is a docker container that's been modified to actually support systemd in a non-hacky way.  This should eliminate some issues with service resources not being idempotent in the containers.
