### PR TITLE
Build Docker containers using internet yum servers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,10 @@
 
 ## Release Notes
 
+## v0.0.7
+
+* Fix yum server name for Infrastructure Design
+
 ## v0.0.6
 
 * fix bug from v0.0.5 with hardcoded image name

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@
 class dockeragent (
   $registry = undef,
   $yum_server = 'master.puppetlabs.vm',
+  $yum_cache = false,
 ){
   include docker
 
@@ -42,6 +43,7 @@ class dockeragent (
         'os_major'   => $::os['release']['major'],
         'yum_server' => $yum_server,
         'basename'   => $image_name,
+        'yum_cache'  => $yum_cache,
         }),
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,8 +6,6 @@ class dockeragent (
 ){
   include docker
 
-  $yum_server_ip = getaddress($yum_server)
-
   $container_volumes =  $::os['release']['major'] ? {
     '6' => [
       '/var/yum:/var/yum',
@@ -42,7 +40,7 @@ class dockeragent (
       ensure         => file,
       content        => epp("dockeragent/${docker_file}.epp",{
         'os_major'   => $::os['release']['major'],
-        'yum_server' => $yum_server_ip,
+        'yum_server' => $yum_server,
         'basename'   => $image_name,
         }),
     }

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     }
   ],
   "name": "pltraining-dockeragent",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "pltraining",
   "summary": "Manages Puppet Labs training classroom environments",
   "license": "Apache 2.0",

--- a/templates/Dockerfile.epp
+++ b/templates/Dockerfile.epp
@@ -5,9 +5,11 @@ MAINTAINER Josh Samuelson <js@puppetlabs.com>
 ENV HOME /root/
 ENV TERM xterm
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/puppet/bin
+<% if $yum_cache { -%>
 ADD base_cache.repo /etc/yum.repos.d/base_cache.repo
 ADD epel_cache.repo /etc/yum.repos.d/epel_cache.repo
 ADD updates_cache.repo /etc/yum.repos.d/updates_cache.repo
+<% } -%>
 ADD yum.conf /etc/yum.conf
 RUN yum -y install  tar dmidecode which logrotate cyrus-sasl libxslt cronie pciutils git rubygems vim tree csh zsh net-tools wget redhat-logos
 RUN gem install multipart-post -v 1.2.0


### PR DESCRIPTION
Build containers using the non-cached yum repos by default.  This is the supported version for the Infrastructure Design.

For Architect, we want to use the MoM's yum cache, so set the yum_cache param to true.
