### PR TITLE
Added rspec base files for testing

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,11 @@
+fixtures:
+  symlinks:
+    dockeragent: "#{source_dir}"
+  repositories:
+  forge_modules:
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: "4.12.0"
+    docker:
+      repo: "garethr/docker"
+      ref: "5.3.0"

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "dockeragent" do
+  let(:node) { 'test.example.com' }
+
+  let(:facts) { {
+    :os                        => {
+      :family                  => 'RedHat',
+      :release => {
+        :major => '7',
+        :minor => '2',
+      }
+    },
+    :osfamily                  => 'RedHat',
+    :operatingsystem           => 'CentOS',
+    :operatingsystemrelease    => '7.2.1511',
+    :operatingsystemmajrelease => '7',
+    :kernel                    => 'Linux',
+    :kernelversion             => '3.10.0',
+  } }
+
+  let(:pre_condition) do
+    <<-EOF
+    EOF
+  end
+
+  it { is_expected.to compile.with_all_deps }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
TRAINTECH-716 #ready for review #time 30m



Puppet-Pirate:~/pltraining/pltraining-dockeragent/spec joaks (TRAINTECH-716)$ rake spec
(in /Users/joaks/pltraining/pltraining-dockeragent)
Notice: Preparing to install into /Users/joaks/pltraining/pltraining-dockeragent/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/Users/joaks/pltraining/pltraining-dockeragent/spec/fixtures/modules
└── puppetlabs-stdlib (v4.12.0)
Notice: Preparing to install into /Users/joaks/pltraining/pltraining-dockeragent/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/Users/joaks/pltraining/pltraining-dockeragent/spec/fixtures/modules
└── garethr-docker (v5.3.0)
/usr/local/Cellar/ruby/2.3.1_2/bin/ruby -I/usr/local/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib:/usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/lib /usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\{aliases,classes,defines,unit,functions,hosts,integration,types\}/\*\*/\*_spec.rb --color
.

Finished in 3.2 seconds (files took 0.91956 seconds to load)
1 example, 0 failures