### PR TITLE
Switch to using default centos container

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-# pltraining/dockeratent
+# pltraining/dockeragent
 
 ## Release Notes
 

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -23,8 +23,8 @@ define dockeragent::image (
     "yum.conf",
   ]
   $image_name = $registry ? {
-    undef   => 'maci0/systemd',
-    default => "${registry}/maci0/systemd",
+    undef   => 'centos:7',
+    default => "${registry}/centos:7",
   }
   $docker_files.each |$docker_file|{
     file { "/etc/docker/${title}/${docker_file}":

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -7,17 +7,11 @@ define dockeragent::node (
 ) {
   require dockeragent
 
-  $container_volumes =  $::os['release']['major'] ? {
-    '6' => [
-      '/var/yum:/var/yum',
-      '/etc/docker/ssl_dir/:/etc/puppetlabs/puppet/ssl',
-    ],
-    '7' => [
-      '/var/yum:/var/yum',
-      '/sys/fs/cgroup:/sys/fs/cgroup:ro',
-      '/etc/docker/ssl_dir/:/etc/puppetlabs/puppet/ssl',
-    ],
-  }
+  $container_volumes = [
+    '/var/yum:/var/yum',
+    '/sys/fs/cgroup:/sys/fs/cgroup:ro',
+    '/etc/docker/ssl_dir/:/etc/puppetlabs/puppet/ssl',
+  ]
 
   docker::run { $title:
     ensure           => $ensure,
@@ -27,9 +21,18 @@ define dockeragent::node (
     ports            => $ports,
     privileged       => $privileged,
     volumes          => $container_volumes,
+    env              =>  [
+      'RUNLEVEL=3',
+      'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      'HOME=/root/',
+      'TERM=xterm'
+    ],
     extra_parameters => [
       "--add-host \"${::fqdn} puppet:${::ipaddress_docker0}\"",
+      '--security-opt seccomp=unconfined',
       '--restart=always',
+      '--tmpfs /tmp',
+      '--tmpfs /run',
     ],
   }
 

--- a/templates/Dockerfile.epp
+++ b/templates/Dockerfile.epp
@@ -1,7 +1,7 @@
 # Builds a basic Centos<%= $os_major %> container with pe-agent installed
 # This image is for training purposes and is not intended for production environments.
 FROM <%= $basename %>
-MAINTAINER Josh Samuelson <js@puppetlabs.com>
+MAINTAINER Josh Samuelson <js@puppet.com>
 ENV HOME /root/
 ENV TERM xterm
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/puppet/bin


### PR DESCRIPTION
systemd now runs correctly in an official centos container. This updates the module to use that rather than the maci0/systemd container which had some hacks to make systemd run inside docker.