### PR TITLE
Use single yum cache instead of localrepo

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -18,10 +18,8 @@ define dockeragent::image (
 
   $docker_files = [
     "Dockerfile",
-    "base_cache.repo",
-    "epel_cache.repo",
     "puppet.conf",
-    "updates_cache.repo",
+    "local_cache.repo",
     "yum.conf",
     "gemrc",
   ]

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -27,6 +27,11 @@ define dockeragent::image (
     undef   => 'centos:7',
     default => "${registry}/centos:7",
   }
+  $gem_source_uri = $gateway_ip ? {
+    undef   => 'file:///var/cache/rubygems/',
+    default => "http://${gateway_ip}:6789",
+  }
+
   $docker_files.each |$docker_file|{
     file { "/etc/docker/${title}/${docker_file}":
       ensure            => file,
@@ -39,7 +44,7 @@ define dockeragent::image (
         'lvm_bashrc'        => $lvm_bashrc,
         'install_dev_tools' => $install_dev_tools,
         'learning_user'     => $learning_user,
-        'gem_source_uri'    => "http://${gateway_ip}:6789",
+        'gem_source_uri'    => $gem_source_uri,
         }),
     }
   }

--- a/templates/base_cache.repo.epp
+++ b/templates/base_cache.repo.epp
@@ -1,5 +1,0 @@
-[base_cache]
-baseurl=https://<%= $gateway_ip %>:8140/packages/yum/base/x86_64
-enabled=1
-name=Base package repo hosted on master
-priority=1

--- a/templates/epel_cache.repo.epp
+++ b/templates/epel_cache.repo.epp
@@ -1,5 +1,0 @@
-[epel_cache]
-baseurl=https://<%= $gateway_ip %>:8140/packages/yum/epel/x86_64
-enabled=1
-name=EPEL packages hosted on the master
-priority=1

--- a/templates/local_cache.repo.epp
+++ b/templates/local_cache.repo.epp
@@ -1,5 +1,5 @@
-[updates_cache]
+[local_cache]
 baseurl=https://<%= $gateway_ip %>:8140/packages/yum/updates/x86_64
 enabled=1
-name=Updates repo hosted on the master
+name=Yum cache repo hosted on the master
 priority=1


### PR DESCRIPTION
This is part of a set of PRs across multiple repos, this particular change is to support using dockeragent in puppetfactory