### PR TITLE
(LEARNVM-636) Disable mcollective

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -10,6 +10,7 @@ define dockeragent::image (
   $install_dev_tools = false,
   $learning_user     = false,
   $image_name        = undef,
+  $disable_mco       = false,
 ){
 
   file { "/etc/docker/${title}/":
@@ -54,6 +55,7 @@ define dockeragent::image (
         'install_dev_tools' => $install_dev_tools,
         'learning_user'     => $learning_user,
         'gem_source_uri'    => $gem_source_uri,
+        'disable_mco'       => $disable_mco,
         }),
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class dockeragent (
   $learning_user         = false,
   $ip_base               = '172.18.0',
   $image_name            = 'agent',
+  $disable_mco           = false,
 ){
   include docker
 
@@ -42,6 +43,7 @@ class dockeragent (
      install_dev_tools => $install_dev_tools,
      learning_user     => $learning_user,
      gateway_ip        => $gateway_ip,
+     disable_mco       => $disable_mco,
    }
 
    dockeragent::image { $image_name:
@@ -54,6 +56,7 @@ class dockeragent (
      learning_user     => $learning_user,
      gateway_ip        => $gateway_ip,
      require           => Dockeragent::Image['no_agent'],
+     disable_mco       => $disable_mco,
    }
 
 }

--- a/templates/puppet.conf.epp
+++ b/templates/puppet.conf.epp
@@ -13,3 +13,6 @@
     localconfig = $vardir/localconfig
     graph = true
     pluginsync = true
+    <%- if $disable_mco { -%>
+    skip_tags = puppet_enterprise::mcollective
+    <%- } -%>


### PR DESCRIPTION
There's no direct way to disable mcollective. It seems like the most
plausible alternative is setting skip_tags in puppet.conf to skip all
resources tagged with puppet_enterprise::mcollective.

The change in this repository adds a parameter to set this option. To
use it, corresponding change will need to be made in the pltraining-bootstrap
repository to set the disable_mco parameter to true.