### PR TITLE
(MAINT) Change skip_tags to mcollective

### DIFF
--- a/templates/puppet.conf.epp
+++ b/templates/puppet.conf.epp
@@ -14,5 +14,5 @@
     graph = true
     pluginsync = true
     <%- if $disable_mco { -%>
-    skip_tags = puppet_enterprise::mcollective
+    skip_tags = mcollective
     <%- } -%>


### PR DESCRIPTION
Including puppet_enterprise::mcollective ends up skipping everything in the puppet_enterprise namespace. Restrict this to only things with the mcollective class.